### PR TITLE
Fix compiled gaphor

### DIFF
--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -333,9 +333,13 @@ def _run_nodejs_script(script_path, arg):
     # Note: path in compiled bytecode is different from straight run
     # so we need to re-export path for nodejs
     # typical nodejs paths
-    sys.path.append("C:/Program Files/nodejs")
-    sys.path.append("/usr/local/bin/node")
-    sys.path.append("/opt/homebrew/bin/node")
+    # sys.path.append("C:/Program Files/nodejs")
+    # sys.path.append("/usr/local/bin/node")
+    # sys.path.append("/opt/homebrew/bin/node")
+    os.environ['PATH'] += os.pathsep + "/usr/local/bin/node"
+    os.environ['PATH'] += os.pathsep + "/opt/homebrew/bin/node"
+    os.environ['PATH'] += os.pathsep + "C:/Program Files/nodejs"
+
 
     cmd = ["node", script_path] + arg
     # cmd = "node " + "\"" + script_path + "\" " + str(arg[0])

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -330,12 +330,18 @@ def _run_nodejs_script(script_path, arg):
     # return elk_runner.layout_json(arg)
     cmd = ["node", script_path] + arg
     # cmd = "node " + "\"" + script_path + "\" " + str(arg[0])
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        print("Error: my_program not found. Check PATH or use absolute path.")
+        print("Current PATH:", os.environ['PATH'])
+        raise Exception("Failed to run node.")
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 
     if result.returncode == 0:
         return result.stdout
     else:
+        print("Error: can't finde node ")
         raise Exception(f"Error running Node.js script: {result.stderr}")
 
 

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import logging
+import sys
 
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
@@ -328,21 +329,27 @@ def _run_nodejs_script(script_path, arg):
     # elk = STPyV8.eval("require('elkjs')")
     # STPyV8.
     # return elk_runner.layout_json(arg)
+
+    # Note: path in compiled bytecode is different from straight run
+    # so we need to re-export path for nodejs
+    # typical nodejs paths
+    sys.path.append("C:/Program Files/nodejs")
+    sys.path.append("/usr/local/bin/node")
+    sys.path.append("/opt/homebrew/bin/node")
+
     cmd = ["node", script_path] + arg
     # cmd = "node " + "\"" + script_path + "\" " + str(arg[0])
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError:
-        print("Error: my_program not found. Check PATH or use absolute path.")
-        print("Current PATH:", os.environ['PATH'])
-        raise Exception("Error: my_program not found. Check PATH or use absolute path. \n Current PATH:", os.environ['PATH'])
+        # cannot find node app
+        raise Exception("Error: NodeJS was not found. Check PATH or use absolute path. Current PATH:", os.environ['PATH'])
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 
     if result.returncode == 0:
         return result.stdout
     else:
-        print("Error: can't finde node ")
-        raise Exception(f"Error running Node.js script: {result.stderr}")
+        raise Exception(f"Error running or finding Node.js script: {result.stderr}")
 
 
 def _as_cluster(presentation: Presentation):

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -335,7 +335,7 @@ def _run_nodejs_script(script_path, arg):
     except FileNotFoundError:
         print("Error: my_program not found. Check PATH or use absolute path.")
         print("Current PATH:", os.environ['PATH'])
-        raise Exception("Failed to run node.")
+        raise Exception("Error: my_program not found. Check PATH or use absolute path. \n Current PATH:", os.environ['PATH'])
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 
     if result.returncode == 0:

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -328,7 +328,7 @@ def _run_nodejs_script(script_path, arg):
     # elk = STPyV8.eval("require('elkjs')")
     # STPyV8.
     # return elk_runner.layout_json(arg)
-    cmd = ["node", script_path] + arg
+    cmd = "node " + script_path + " " + arg
     result = subprocess.run(cmd, capture_output=True, text=True, check=False, shell=True)
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -336,12 +336,18 @@ def _run_nodejs_script(script_path, arg):
     # sys.path.append("C:/Program Files/nodejs")
     # sys.path.append("/usr/local/bin/node")
     # sys.path.append("/opt/homebrew/bin/node")
-    os.environ['PATH'] += os.pathsep + "/usr/local/bin/node"
-    os.environ['PATH'] += os.pathsep + "/opt/homebrew/bin/node"
-    os.environ['PATH'] += os.pathsep + "C:/Program Files/nodejs"
+    # evaluate nodejs path executable
+    if os.path.exists("/usr/local/bin/node"):
+        node_exc = r"/usr/local/bin/node"
+    elif os.path.exists("/opt/homebrew/bin/node"):
+        node_exc = r"/opt/homebrew/bin/node"
+    elif os.path.exists("C:/Program Files/nodejs"):
+        node_exc = r"C:/Program Files/nodejs.exe"
+    else:
+        raise Exception("Can't find nodejs executable")
 
 
-    cmd = ["node", script_path] + arg
+    cmd = [node_exc, script_path] + arg
     # cmd = "node " + "\"" + script_path + "\" " + str(arg[0])
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=False)

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -323,20 +323,7 @@ def _add_to_graph(parent, edge_or_node) -> None:
 
 def _run_nodejs_script(script_path, arg):
     """run Node.js script from python"""
-
-    # elk_runner = pm.require(os.path.splitext(script_path)[0])
-    # elk = pm.eval("require('elkjs')")
-    # elk = STPyV8.eval("require('elkjs')")
-    # STPyV8.
-    # return elk_runner.layout_json(arg)
-
-    # Note: path in compiled bytecode is different from straight run
-    # so we need to re-export path for nodejs
-    # typical nodejs paths
-    # sys.path.append("C:/Program Files/nodejs")
-    # sys.path.append("/usr/local/bin/node")
-    # sys.path.append("/opt/homebrew/bin/node")
-    # evaluate nodejs path executable
+    # Note: path in compiled bytecode is different from straight run so we need to find the NodeJS executable
     if os.path.exists("/usr/local/bin/node"):
         node_exc = r"/usr/local/bin/node"
     elif os.path.exists("/opt/homebrew/bin/node"):
@@ -346,15 +333,12 @@ def _run_nodejs_script(script_path, arg):
     else:
         raise Exception("Can't find nodejs executable")
 
-
     cmd = [node_exc, script_path] + arg
-    # cmd = "node " + "\"" + script_path + "\" " + str(arg[0])
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError:
         # cannot find node app
         raise Exception("Error: NodeJS was not found. Check PATH or use absolute path. Current PATH:", os.environ['PATH'])
-    # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 
     if result.returncode == 0:
         return result.stdout

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -328,8 +328,8 @@ def _run_nodejs_script(script_path, arg):
     # elk = STPyV8.eval("require('elkjs')")
     # STPyV8.
     # return elk_runner.layout_json(arg)
-    # cmd = ["node", script_path] + arg
-    cmd = "node " + "\"" + script_path + "\" " + str(arg[0])
+    cmd = ["node", script_path] + arg
+    # cmd = "node " + "\"" + script_path + "\" " + str(arg[0])
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -329,7 +329,7 @@ def _run_nodejs_script(script_path, arg):
     # STPyV8.
     # return elk_runner.layout_json(arg)
     cmd = ["node", script_path] + arg
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, shell=True)
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 
     if result.returncode == 0:

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -328,7 +328,8 @@ def _run_nodejs_script(script_path, arg):
     # elk = STPyV8.eval("require('elkjs')")
     # STPyV8.
     # return elk_runner.layout_json(arg)
-    cmd = "node " + script_path + " " + str(arg[0])
+    # cmd = ["node", script_path] + arg
+    cmd = "node " + "\"" + script_path + "\" " + str(arg[0])
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -2,7 +2,6 @@ import json
 import os
 import subprocess
 import logging
-import sys
 
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
@@ -338,7 +337,10 @@ def _run_nodejs_script(script_path, arg):
         result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError:
         # cannot find node app
-        raise Exception("Error: NodeJS was not found. Check PATH or use absolute path. Current PATH:", os.environ['PATH'])
+        raise Exception(
+            "Error: NodeJS was not found. Check PATH or use absolute path. Current PATH:",
+            os.environ["PATH"],
+        )
 
     if result.returncode == 0:
         return result.stdout

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -328,8 +328,8 @@ def _run_nodejs_script(script_path, arg):
     # elk = STPyV8.eval("require('elkjs')")
     # STPyV8.
     # return elk_runner.layout_json(arg)
-    cmd = "node " + script_path + " " + arg[0]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False, shell=True)
+    cmd = "node " + script_path + " " + str(arg[0])
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 
     if result.returncode == 0:

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -328,7 +328,7 @@ def _run_nodejs_script(script_path, arg):
     # elk = STPyV8.eval("require('elkjs')")
     # STPyV8.
     # return elk_runner.layout_json(arg)
-    cmd = "node " + script_path + " " + arg
+    cmd = "node " + script_path + " " + arg[0]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False, shell=True)
     # result = pm.run([script_path] + arg, capture_output=True, text=True, check=False)
 


### PR DESCRIPTION
Compiled bytecode uses a different environment from running raw python. This requires finding the nodejs executable. Using common paths as search for MacOS, Windows, and Linux.

