### PR TITLE
Add new layout options - top down

### DIFF
--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -168,7 +168,7 @@ def layout_properties_topdown() -> dict:
         "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "20.0",  # layer to layer placement
         "org.eclipse.elk.spacing.nodeSelfLoop": "20.0",  # space for arrows on self-loops,
         "org.eclipse.elk.font.size": "12",  # default font size for labels (not sure if this does anything)
-        "org.eclipse.elk.core.options.Direction": "RIGHT",
+        "org.eclipse.elk.core.options.Direction": "DOWN",
     }
     return properties
 

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -32,7 +32,6 @@ from gaphor.UML.actions.activitynodes import ForkNodeItem
 from gaphor.UML.classes import AssociationItem, DependencyItem, GeneralizationItem
 
 log = logging.getLogger(__name__)
-logging.basicConfig(filename='myapp.log', level=logging.INFO)
 
 @dataclass
 class BaseItem:
@@ -210,10 +209,11 @@ class AutoLayoutELK:
 
         # render graph using ELKjs engine
         json_export = self.convert_graph()
+        log.info("Exported layout graph", json_export)
         current_directory = os.path.dirname(os.path.abspath(__file__))
         elkjs_runner = os.path.join(current_directory, "elkrunner.js")
         rendered_graph_as_str = _run_nodejs_script(elkjs_runner, [json_export])
-        log.info("rendering graph", rendered_graph_as_str)
+        log.info("Elk rendered graph", rendered_graph_as_str)
         rendered_graph_as_dict = json.loads(rendered_graph_as_str)
 
         # get resulting node locations for use late

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -168,7 +168,7 @@ def layout_properties_topdown() -> dict:
         "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "20.0",  # layer to layer placement
         "org.eclipse.elk.spacing.nodeSelfLoop": "20.0",  # space for arrows on self-loops,
         "org.eclipse.elk.font.size": "12",  # default font size for labels (not sure if this does anything)
-        "org.eclipse.elk.core.options.Direction": "DOWN",
+        "elk.direction": "DOWN",
     }
     return properties
 

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -150,7 +150,7 @@ def layout_properties_normal() -> dict:
         "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "20.0",  # layer to layer placement
         "org.eclipse.elk.spacing.nodeSelfLoop": "20.0",  # space for arrows on self-loops,
         "org.eclipse.elk.font.size": "12",  # default font size for labels (not sure if this does anything)
-        "org.eclipse.elk.layered.wrapping.strategy" : "SINGLE_EDGE"
+        "elk.layered.wrapping.strategy" : "SINGLE_EDGE",
     }
     return properties
 
@@ -169,6 +169,7 @@ def layout_properties_topdown() -> dict:
         "org.eclipse.elk.spacing.nodeSelfLoop": "20.0",  # space for arrows on self-loops,
         "org.eclipse.elk.font.size": "12",  # default font size for labels (not sure if this does anything)
         "elk.direction": "DOWN",
+        "elk.layered.wrapping.strategy": "SINGLE_EDGE",
     }
     return properties
 

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import logging
+import typing
 
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
@@ -31,7 +32,7 @@ from gaphor.UML.actions.activitynodes import ForkNodeItem
 from gaphor.UML.classes import AssociationItem, DependencyItem, GeneralizationItem
 
 log = logging.getLogger(__name__)
-
+logging.basicConfig(filename='myapp.log', level=logging.INFO)
 
 @dataclass
 class BaseItem:
@@ -150,7 +151,7 @@ def layout_properties_normal() -> dict:
         "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "20.0",  # layer to layer placement
         "org.eclipse.elk.spacing.nodeSelfLoop": "20.0",  # space for arrows on self-loops,
         "org.eclipse.elk.font.size": "12",  # default font size for labels (not sure if this does anything)
-        "elk.layered.wrapping.strategy" : "SINGLE_EDGE",
+        "elk.layered.wrapping.strategy" : "MULTI_EDGE",
     }
     return properties
 
@@ -169,7 +170,7 @@ def layout_properties_topdown() -> dict:
         "org.eclipse.elk.spacing.nodeSelfLoop": "20.0",  # space for arrows on self-loops,
         "org.eclipse.elk.font.size": "12",  # default font size for labels (not sure if this does anything)
         "elk.direction": "DOWN",
-        "elk.layered.wrapping.strategy": "SINGLE_EDGE",
+        "elk.layered.wrapping.strategy": "MULTI_EDGE",
     }
     return properties
 
@@ -197,11 +198,13 @@ class AutoLayoutELK:
         self.event_manager = event_manager
         self.graph: Node | None = None
 
-    def layout(self, diagram: Diagram, layout_props: dict) -> None:
+    def layout(self, diagram: Diagram, layout_props: typing.Optional[dict] = None) -> None:
         """Generate the layout from ELKjs"""
         diagram.update(diagram.ownedPresentation)
         # in the future, adjust layout properties based on the diagram type
-        layout_props = layout_props
+        if layout_props is None:
+            layout_props = layout_properties_normal()
+
         self.graph = baseline_graph(layout_props)
         self.generate_graph(diagram)
 
@@ -210,6 +213,7 @@ class AutoLayoutELK:
         current_directory = os.path.dirname(os.path.abspath(__file__))
         elkjs_runner = os.path.join(current_directory, "elkrunner.js")
         rendered_graph_as_str = _run_nodejs_script(elkjs_runner, [json_export])
+        log.info("rendering graph", rendered_graph_as_str)
         rendered_graph_as_dict = json.loads(rendered_graph_as_str)
 
         # get resulting node locations for use late
@@ -353,7 +357,7 @@ def _add_to_graph(parent, edge_or_node) -> None:
 
 def _run_nodejs_script(script_path, arg):
     """run Node.js script from python"""
-    # Note: path in compiled bytecode is different from straight run so we need to find the NodeJS executable
+    # Note: the path in compiled bytecode is different from straight run so we need to find the NodeJS executable
     if os.path.exists("/usr/local/bin/node"):
         node_exc = r"/usr/local/bin/node"
     elif os.path.exists("/opt/homebrew/bin/node"):
@@ -501,7 +505,7 @@ def _(presentation: ElementPresentation):
             "org.eclipse.elk.nodeSize.constraints": "MINIMUM_SIZE",
         }
 
-        # comments can be placed out special (allow for more flexibility as opposed to left to right)
+        # comments can be placed out special (allow for more flexibility as opposed to the left to right)
         if isinstance(presentation, Comment):
             node_layout_options["org.eclipse.elk.commentBox"] = "true"
 
@@ -543,9 +547,14 @@ def _(presentation: ElementPresentation):
         # I don't understand what this is protecting against.
         # If there is a single element, then it should be a node
 
+        # check if the node is a comment
+        node_layout_options = {}
+        if isinstance(presentation, Comment):
+            node_layout_options["org.eclipse.elk.commentBox"] = "true"
+
         yield Node(
             id=presentation.id,
-            properties={},
+            properties=node_layout_options,
             x=None,
             y=None,
             width=presentation.width,

--- a/gaphor_autolayout/autolayoutelk.py
+++ b/gaphor_autolayout/autolayoutelk.py
@@ -376,7 +376,7 @@ def _run_nodejs_script(script_path, arg):
     if result.returncode == 0:
         return result.stdout
     else:
-        raise Exception(f"Error running or finding Node.js script: {result.stderr}")
+        raise Exception(f"Error running or finding Node.js script: {result.stderr} with the following input: {arg[0]}")
 
 
 def _as_cluster(presentation: Presentation):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
-  "name": "gaphor-autolayout",
+  "name": "autolayoutelk",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "autolayoutelk",
+      "version": "0.1.0",
       "dependencies": {
-        "elkjs": "^0.9.3"
+        "elkjs": "^0.10.0"
       }
     },
     "node_modules/elkjs": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
-      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.10.0.tgz",
+      "integrity": "sha512-v/3r+3Bl2NMrWmVoRTMBtHtWvRISTix/s9EfnsfEWApNrsmNjqgqJOispCGg46BPwIFdkag3N/HYSxJczvCm6w==",
       "license": "EPL-2.0"
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Supporting runner scripts for autolayout with gaphor",
   "main": "./gaphor_autolayout/elkrunner.js",
   "dependencies": {
-    "elkjs": "^0.9.3"
+    "elkjs": "^0.10.0"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gaphor-autolayout"
-version = "0.1.0"
+version = "0.2.0"
 description = "Auto layout diagrams using ELK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_elklayout.py
+++ b/tests/test_elklayout.py
@@ -8,7 +8,7 @@ from gaphor import UML
 from gaphor_autolayout.autolayoutelk import (
     AutoLayoutELK,
     _parse_edge_pos,
-    _strip_quotes,
+    _strip_quotes, layout_properties_normal,
 )
 
 from gaphor.UML.diagramitems import (
@@ -129,8 +129,9 @@ def test_layout_with_association(diagram, create, event_manager):
     connect(a, a.head, c1)
     connect(a, a.tail, c2)
 
-    auto_layout = AutoLayoutELK(event_manager)
-    auto_layout.layout(diagram)
+    layout_props = layout_properties_normal()
+    auto_layout = AutoLayoutELK()
+    auto_layout.layout(diagram, layout_props)
 
 
 # def test_layout_with_comment(diagram, create, event_manager):
@@ -162,8 +163,9 @@ def test_layout_with_nested(diagram, create, event_manager):
     connect(a, a.head, c1)
     connect(a, a.tail, c2)
 
-    auto_layout = AutoLayoutELK(event_manager)
-    auto_layout.layout(diagram)
+    layout_props = layout_properties_normal()
+    auto_layout = AutoLayoutELK()
+    auto_layout.layout(diagram, layout_props)
 
     assert c1.matrix[4] < p.width
     assert c1.matrix[5] < p.height
@@ -179,8 +181,9 @@ def test_layout_with_attached_item(diagram, create, event_manager):
     connect(object_flow, object_flow.head, pin)
     connect(object_flow, object_flow.tail, action2)
 
-    auto_layout = AutoLayoutELK(event_manager)
-    auto_layout.layout(diagram)
+    layout_props = layout_properties_normal()
+    auto_layout = AutoLayoutELK()
+    auto_layout.layout(diagram, layout_props)
 
     assert pin.parent is action
 


### PR DESCRIPTION
Adds top-down or left-to-right layout options. 

Change also allows the passing of custom layout properties when running direct from python. 

## usage
``` python
layout_props = layout_properties_normal()
auto_layout = AutoLayoutELK()
auto_layout.layout(diagram, layout_props)
```